### PR TITLE
fix: changing major, minor and patch to let and setting minor and patch to zero for breaking change

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,9 +71,9 @@ const run = async () => {
             return
         }
 
-        const major = parseInt(major_str)
-        const minor = parseInt(minor_str)
-        const patch = parseInt(patch_str)
+        let major = parseInt(major_str)
+        let minor = parseInt(minor_str)
+        let patch = parseInt(patch_str)
 
         if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
             console.log("Not a number. Previous tag was does not follow the format: v0.0.0. Creating a new tag")

--- a/index.js
+++ b/index.js
@@ -88,6 +88,8 @@ const run = async () => {
         if (argument === "breaking" || argument === "break") {
             console.log("This is a breaking change")
             major += 1
+            minor = 0
+            patch = 0
         } else if (minor_arguments.includes(argument)) {
             console.log("This is a minor change")
             minor += 1


### PR DESCRIPTION
- Can't be expecting to add 1 to a const variable now can we?
- minor and patch should be set to 0 whenever there is a breaking change

This PR is built upon the failures of: 
1. https://github.com/developerdenesh/pr_versioning/pull/2
2. https://github.com/developerdenesh/pr_versioning/pull/1